### PR TITLE
Update to latest Deephaven version and remove dependency on dagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ repositories {
 
 dependencies {
     implementation "io.deephaven:deephaven-java-client-barrage"
-    implementation "io.deephaven:deephaven-java-client-barrage-dagger"
     implementation platform("io.deephaven:deephaven-bom:$dhcVersion")
 
     runtimeOnly "io.deephaven:deephaven-log-to-slf4j"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-dhcVersion=0.33.2
+dhcVersion=0.34.2


### PR DESCRIPTION
This updates to the newer, recommended way of creating sessions. It removes the dependency on dagger and presents a ClientConfig object. See https://github.com/deephaven/deephaven-core/pull/5386